### PR TITLE
pdf2md-cli: create .md files in sequence

### DIFF
--- a/lib/pdf2md-cli.js
+++ b/lib/pdf2md-cli.js
@@ -75,20 +75,20 @@ function makeOutputDirs (allOutputPaths) {
   })
 }
 
-function createMarkdownFiles (filePaths, allOutputPaths) {
+async function createMarkdownFiles (filePaths, allOutputPaths) {
   // If outputPath specified, supply callbacks to log progress
-  filePaths.forEach(async function (filePath, i) {
+  for (let i = 0; i < filePaths.length; ++i) {
+    const filePath = filePaths[i]
     const callbacks = allOutputPaths[i] && {}
     const pdfBuffer = fs.readFileSync(filePath)
-    pdf2md(pdfBuffer, callbacks)
-      .then(text => {
-        const outputFile = allOutputPaths[i] + '.md'
-        console.log(`Writing to ${outputFile}...`)
-        fs.writeFileSync(path.resolve(outputFile), text)
-        console.log('Done.')
-      })
-      .catch(err => {
-        console.error(err)
-      })
-  })
+    try {
+      const text = await pdf2md(pdfBuffer, callbacks)
+      const outputFile = allOutputPaths[i] + '.md'
+      console.log(`Writing to ${outputFile}...`)
+      fs.writeFileSync(path.resolve(outputFile), text)
+      console.log('Done.')
+    } catch (err) {
+      console.error(err)
+    }
+  }
 }


### PR DESCRIPTION
Do not use `filePaths.forEach` to iterate over the input PDFs, as we
have to await on pdfjs (via pdf2md) to complete before moving to the
next file

Fixes #20 