### PR TITLE
hotfix findFirstPage() - TypeError cannot read property length

### DIFF
--- a/lib/util/page-number-functions.js
+++ b/lib/util/page-number-functions.js
@@ -68,7 +68,9 @@ exports.findFirstPage = (pageIndexNumMap) => {
     const firstPage = pageIndexNumMap[keys[x]]
     const secondPage = pageIndexNumMap[keys[x + 1]]
     const prevCounter = counter
-
+    if (typeof firstPage == 'undefined' || typeof secondPage == 'undefined'){
+      break
+    }
     for (let y = 0; y < firstPage.length && counter < 2; y++) {
       for (let z = 0; z < secondPage.length && counter < 2; z++) {
         const pageDifference = keys[x + 1] - keys[x]

--- a/lib/util/pdf.js
+++ b/lib/util/pdf.js
@@ -41,8 +41,9 @@ exports.parse = async function parse (docOptions, callbacks) {
       break
     }
   }
-
-  let pageNum = firstPage.pageNum
+  if (typeof firstPage != 'undefined'){
+    let pageNum = firstPage.pageNum
+  }
   for (let j = 1; j <= pdfDocument.numPages; j++) {
     const page = await pdfDocument.getPage(j)
 
@@ -52,9 +53,11 @@ exports.parse = async function parse (docOptions, callbacks) {
     const scale = 1.0
     const viewport = page.getViewport({ scale })
     let textContent = await page.getTextContent()
-    if (page.pageIndex >= firstPage.pageIndex) {
-      textContent = removePageNumber(textContent, pageNum)
-      pageNum++
+    if (typeof firstPage != 'undefined'){
+      if (page.pageIndex >= firstPage.pageIndex) {
+        textContent = removePageNumber(textContent, pageNum)
+        pageNum++
+      }
     }
     const textItems = textContent.items.map(item => {
       const tx = pdfjs.Util.transform(


### PR DESCRIPTION
I've been getting a TypeError from the findFirstPage() function where if you couldn't detect the length, it just halted the parse.
Just added a hotfix of checking for typeof and escaping it but unsure if this will have further downstream consequences.

<pre>
TypeError: Cannot read property 'length' of undefined
    at exports.findFirstPage (/home/10e/pdf2md/lib/util/page-number-functions.js:73:40)
    at parse (/home/10e/pdf2md/lib/util/pdf.js:40:19)
</pre>