### PR TITLE
Fix reading length of undefined at findFirstPage

### DIFF
--- a/lib/util/page-number-functions.js
+++ b/lib/util/page-number-functions.js
@@ -67,7 +67,7 @@ exports.findFirstPage = (pageIndexNumMap) => {
     return
   }
 
-  for (let x = 0; x < keys.length; x++) {
+  for (let x = 0; x < keys.length - 1; x++) {
     const firstPage = pageIndexNumMap[keys[x]]
     const secondPage = pageIndexNumMap[keys[x + 1]]
     const prevCounter = counter


### PR DESCRIPTION
```
TypeError: Cannot read property 'length' of undefined
    at exports.findFirstPage (/usr/lib/node_modules/@opendocsg/pdf2md/lib/util/page-number-functions.js:76:38)
    at parse (/usr/lib/node_modules/@opendocsg/pdf2md/lib/util/pdf.js:40:19)
    at async module.exports (/usr/lib/node_modules/@opendocsg/pdf2md/lib/pdf2md.js:22:18)
    at async createMarkdownFiles (/usr/lib/node_modules/@opendocsg/pdf2md/lib/pdf2md-cli.js:55:20)
```

Loop will continue until `firstPage < keys.length`, but since keys are zero-based, it leaves the final `secondPage` at undefined.
This PR attempts to fix it.
