### PR TITLE
Remove pdf extension from original file name

### DIFF
--- a/lib/pdf2md-cli.js
+++ b/lib/pdf2md-cli.js
@@ -27,7 +27,9 @@ function run (folderPath, outputPath, recursive = true) {
   var [filePaths, folderPaths] = getFileAndFolderPaths(folderPath)
   var [allFilePaths] = getAllFileAndFolderPaths(filePaths, folderPaths, recursive)
   var allOutputPaths = allFilePaths.map(x => {
-    return outputPath + x.split(folderPath)[1].split('.')[0]
+    const fileNameWithExtension = x.split(folderPath)[1]
+    const fileNameWithoutExtension = fileNameWithExtension.slice(0, fileNameWithExtension.indexOf(".pdf"))
+    return outputPath + fileNameWithoutExtension
   })
   makeOutputDirs(allOutputPaths)
   createMarkdownFiles(allFilePaths, allOutputPaths)


### PR DESCRIPTION
**Reference Issues/PRs**
Fixes #46

**What does this implement/fix? Explain your changes.**
Instead of splitting original file name by `.`, file extension `.pdf` is removed from file name.