### PR TITLE
Add code coverage & some test cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log
 .eslintcache
 dist/
 output/
+.nyc_output/

--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,9 @@
+{
+  "all": true,
+  "include": [
+    "lib/**"
+  ],
+  "exclude": [
+    "test/**/*.spec.js"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint lib --cache",
     "test": "mocha test --recursive",
     "test:watch": "mocha test --recursive --watch",
+    "test:coverage": "nyc npm run test",
     "check": "npm run lint && npm run test"
   },
   "keywords": [
@@ -51,6 +52,7 @@
     "flow-bin": "^0.102.0",
     "mocha": "^8.2.1",
     "mock-fs": "^4.10.1",
+    "nyc": "^15.1.0",
     "rewire": "^5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "mocha test --recursive",
     "test:watch": "mocha test --recursive --watch",
     "test:coverage": "nyc npm run test",
-    "check": "npm run lint && npm run test"
+    "check": "npm run lint && npm run test:coverage"
   },
   "keywords": [
     "PDF",

--- a/test/models/StashingStream.spec.js
+++ b/test/models/StashingStream.spec.js
@@ -27,6 +27,10 @@ describe('StashingStream', () => {
     expect(stream.transformedItems).to.equal(10)
   })
 
+  it('Constructor Execption', () => {
+    expect(() => new StashingStream()).to.throw('Can not construct abstract class.')
+  })
+
   it('ConsumeAll', () => {
     const items = ['k', 'k', 'x', 'a', 'm', 'z', 'o', 'p']
     const stream = new MyStashingStream()
@@ -35,6 +39,26 @@ describe('StashingStream', () => {
     const resultsAsString = stream.complete().join('')
     expect(resultsAsString).to.equal('kkxAZop')
     expect(stream.transformedItems).to.equal(3)
+  })
+
+  it('shouldStash Throw Error', () => {
+    const stream = new MyStashingStream()
+
+    expect(() => stream.shouldStashFromParent('a')).to.throw(' Do not call abstract method foo from child.a')
+  })
+
+  it('doMatchesStash Throw Error', () => {
+    const items = ['k', 'k', 'x', 'a', 'm', 'z', 'o', 'p']
+    const stream = new MyStashingStream()
+    stream.consumeAll(items)
+
+    expect(() => stream.doMatchesStashFromParent('p', 'q')).to.throw(' Do not call abstract method foo from child.pq')
+  })
+
+  it('doFlushStash Throw Error', () => {
+    const stream = new MyStashingStream()
+
+    expect(() => stream.doFlushStashFromParent(['a'], [])).to.throw(' Do not call abstract method foo from child.a')
   })
 })
 
@@ -48,12 +72,24 @@ class MyStashingStream extends StashingStream {
     return item === 'a' || item === 'z' || item === 'm'
   }
 
+  shouldStashFromParent (item) {
+    return super.shouldStash(item)
+  }
+
   doMatchesStash (lastItem, item) {
     return lastItem === item
+  }
+
+  doMatchesStashFromParent (lastItem, item) {
+    return super.doMatchesStash(lastItem, item)
   }
 
   doFlushStash (stash, results) {
     this.transformedItems += stash.length
     results.push(...stash.filter(elem => elem !== 'm').map(item => item.toUpperCase()))
+  }
+
+  doFlushStashFromParent (stash, results) {
+    super.doFlushStash(stash, results)
   }
 }

--- a/test/util/cli.spec.js
+++ b/test/util/cli.spec.js
@@ -22,6 +22,8 @@ describe('functions: entry point file retrieval', function () {
     const [fileNames, folderNames] = getFileAndFolderPaths('root')
     expect(fileNames).to.have.members(['root/pdf-file-1.pdf', 'root/pdf-file-2.pdf'])
     expect(folderNames).to.have.members(['root/dir-1', 'root/dir-2', 'root/dir-3'])
+
+    mock.restore()
   })
 
   it('Assert getAllPaths from a single directory returns the proper arrays, recursive', function () {
@@ -51,6 +53,8 @@ describe('functions: entry point file retrieval', function () {
     expect(allFolderNames).to.have.members(['root/dir-1',
       'root/dir-2',
       'root/dir-3'])
+
+    mock.restore()
   })
 
   it('Assert getAllPaths from a single directory returns the proper arrays, non-recursive', function () {
@@ -74,5 +78,7 @@ describe('functions: entry point file retrieval', function () {
 
     expect(allFileNames).to.have.members(['root/pdf-file-1.pdf', 'root/pdf-file-2.pdf'])
     expect(allFolderNames).to.have.members(['root/dir-1', 'root/dir-2', 'root/dir-3'])
+
+    mock.restore()
   })
 })

--- a/test/util/string-functions.spec.js
+++ b/test/util/string-functions.spec.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai')
 
-const { hasUpperCaseCharacterInMiddleOfWord, normalizedCharCodeArray, removeLeadingWhitespaces, removeTrailingWhitespaces, prefixAfterWhitespace, suffixBeforeWhitespace, charCodeArray, isListItem, isNumberedListItem, wordMatch } = require('../../lib/util/string-functions')
+const { hasUpperCaseCharacterInMiddleOfWord, normalizedCharCodeArray, removeLeadingWhitespaces, removeTrailingWhitespaces, prefixAfterWhitespace, suffixBeforeWhitespace, charCodeArray, isListItem, isNumberedListItem, wordMatch, hasOnly, isListItemCharacter } = require('../../lib/util/string-functions')
 
 describe('functions: hasUpperCaseCharacterInMiddleOfWord', () => {
   it('single word', () => {
@@ -176,5 +176,36 @@ describe('functions: wordsMatch', () => {
     expect(wordMatch('text', 'test')).to.equal(0.0)
 
     expect(wordMatch('inStruCtionS for the full Moon proCeSS', 'Instructions for the Full Moon Process')).to.equal(1.0)
+  })
+})
+
+describe('functions: hasOnly', () => {
+  it('Match', () => {
+    expect(hasOnly('a', 'a')).to.equal(true)
+    expect(hasOnly('aaaa', 'a')).to.equal(true)
+  })
+
+  it('No Match', () => {
+    expect(hasOnly('abc', 'a')).to.equal(false)
+    expect(hasOnly('abc', '')).to.equal(false)
+    expect(hasOnly('abc', 'ab')).to.equal(false)
+    expect(hasOnly('abc', '1')).to.equal(false)
+  })
+})
+
+describe('functions: isListItemCharacter', () => {
+  it('Match', () => {
+    expect(isListItemCharacter('-')).to.equal(true)
+    expect(isListItemCharacter('•')).to.equal(true)
+    expect(isListItemCharacter('–')).to.equal(true)
+  })
+
+  it('No Match', () => {
+    expect(isListItemCharacter('--')).to.equal(false)
+    expect(isListItemCharacter('••')).to.equal(false)
+    expect(isListItemCharacter('––')).to.equal(false)
+    expect(isListItemCharacter('')).to.equal(false)
+    expect(isListItemCharacter('a')).to.equal(false)
+    expect(isListItemCharacter('abc')).to.equal(false)
   })
 })


### PR DESCRIPTION
List of Changes
1. Added NYC module for code coverage, you can run code coverage by execute this command: `npm run test:coverage`
2. Added whitelist JS file for code coverage on `.nycrc`
3. Added some test cases for `StashingStream.spec.js` and `string-functions.spec.js`
4. Fixed the existing testcases due to integration with NYC module (`cli.spec.js`)
5. Change default sub-command on `npm run check` to `npm run test:coverage` instead of `npm run test` (`package.json`)